### PR TITLE
CLD-2236: Modified kinesis stream data read permissions only for integrated stream.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,13 +8,20 @@ data "aws_s3_bucket" "cloudtrail_log_bucket_arn" {
   bucket = var.cloudtrail_s3_bucket_name
 }
 
+data "aws_kinesis_stream" "kinesis_stream_arn" {
+  count = var.kinesis_stream_enabled ? 1 : 0
+  name  = var.kinesis_stream_name
+}
+
 module "instance_profile" {
   source                    = "./modules/iam-profile"
   resource_prefix           = var.resource_prefix
   cloud_logs_enabled        = var.cloud_logs_enabled
+  kinesis_stream_enabled    = var.kinesis_stream_enabled
   aws_account_id            = var.aws_account_id
   external_id               = var.external_id
   cloudtrail_log_bucket_arn = var.cloud_logs_enabled != false ? data.aws_s3_bucket.cloudtrail_log_bucket_arn[0].arn : null
   vpc_log_bucket_arn        = var.cloud_logs_enabled != false ? data.aws_s3_bucket.vpc_log_bucket_arn[0].arn : null
+  kinesis_stream_arn        = var.kinesis_stream_enabled != false ? data.aws_kinesis_stream.kinesis_stream_arn[0].arn : null
   tags                      = var.tags
 }

--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy_attachment" "ReadOnlyPolicy_attach" {
 resource "aws_iam_policy" "ReadOnlyPolicy" {
   name        = "${var.resource_prefix}-ReadOnlyPolicy"
   description = "Given Read Only policy Access to service."
-  policy = <<EOF
+  policy      = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -69,8 +69,6 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
               "codepipeline:ListTagsForResource",
               "codepipeline:GetPipeline",
               "ds:ListTagsForResource",
-              "kinesis:GetShardIterator",
-              "kinesis:GetRecords",
               "kinesis:DescribeStream",
               "servicecatalog:SearchProducts",
               "servicecatalog:DescribeProduct",
@@ -88,7 +86,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "cloudtrail_bucket_policy_attach" {
   # Only required when cloud logs are enabled
-  count = var.cloud_logs_enabled ? 1 : 0
+  count      = var.cloud_logs_enabled ? 1 : 0
   role       = aws_iam_role.role.name
   policy_arn = aws_iam_policy.cloud_trail_bucketPolicy[0].arn
 
@@ -96,10 +94,10 @@ resource "aws_iam_role_policy_attachment" "cloudtrail_bucket_policy_attach" {
 
 resource "aws_iam_policy" "cloud_trail_bucketPolicy" {
   # Only required when cloud logs are enabled
-  count  = var.cloud_logs_enabled ? 1 : 0
+  count       = var.cloud_logs_enabled ? 1 : 0
   name        = "${var.resource_prefix}-cloudtrail-bucket-policy"
   description = "Cloudtrail Bucket Policy "
-  policy = <<EOF
+  policy      = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -117,18 +115,18 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "VpcFlowLogBucketPolicy_attach" {
   # Only required when cloud logs are enabled
-  count  = var.cloud_logs_enabled ? 1 : 0
-  role = aws_iam_role.role.name
+  count      = var.cloud_logs_enabled ? 1 : 0
+  role       = aws_iam_role.role.name
   policy_arn = aws_iam_policy.VpcFlowLogBucketPolicy[0].arn
 
 }
 
 resource "aws_iam_policy" "VpcFlowLogBucketPolicy" {
   # Only required when cloud logs are enabled
-  count  = var.cloud_logs_enabled ? 1 : 0
+  count       = var.cloud_logs_enabled ? 1 : 0
   name        = "${var.resource_prefix}-vpc-flowlog-bucket-policy"
   description = "Vpc Flow Log Bucket Policy "
-  policy = <<EOF
+  policy      = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -136,6 +134,38 @@ resource "aws_iam_policy" "VpcFlowLogBucketPolicy" {
             "Effect": "Allow",
             "Action": [ "s3:GetObject" ],
             "Resource": [ "${var.vpc_log_bucket_arn}/*" ]
+        }
+    ]
+}
+EOF
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "kinesis_stream_policy_attach" {
+  # Only required when kinesis stream for cloudtrail logs is enabled
+  count      = var.kinesis_stream_enabled ? 1 : 0
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.kinesis_stream_policy[0].arn
+
+}
+
+resource "aws_iam_policy" "kinesis_stream_policy" {
+  # Only required when kinesis stream for cloudtrail logs is enabled
+  count       = var.kinesis_stream_enabled ? 1 : 0
+  name        = "${var.resource_prefix}-kinesis-stream-policy"
+  description = "Kinesis Stream Policy "
+  policy      = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [ 
+              "kinesis:GetShardIterator", 
+              "kinesis:GetRecords"
+            ],
+            "Resource": [ "${var.kinesis_stream_arn}" ]
         }
     ]
 }

--- a/modules/iam-profile/variables.tf
+++ b/modules/iam-profile/variables.tf
@@ -35,9 +35,18 @@ variable "cloudtrail_log_bucket_arn" {
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)
-  default = {}
+  default     = {}
 }
 
+variable "kinesis_stream_enabled" {
+  description = "Whether customer wants to integrate kinesis data stream for cloudtrail logs. "
+  type        = bool
+  default     = false
+}
 
-
+variable "kinesis_stream_arn" {
+  description = "ARN for kinesis data stream for cloudtrail logs (if kinesis_stream_enabled is set to true)"
+  type        = string
+  default     = ""
+}
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,8 +32,20 @@ variable "cloudtrail_s3_bucket_name" {
   default     = ""
 }
 
+variable "kinesis_stream_enabled" {
+  description = "Whether customer wants to integrate kinesis data stream for cloudtrail logs. "
+  type        = bool
+  default     = false
+}
+
+variable "kinesis_stream_name" {
+  description = "Kinesis stream name for cloudtrail logs (if kinesis_stream_enabled is set to true)"
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply to the resources created by this module"
   type        = map(string)
-  default = {}
+  default     = {}
 }


### PR DESCRIPTION
- We were not assigning granular permissions for Kinesis stream earlier; giving rise to unnecessary `ReadRecords`, `GetShardIterator` permissions for kinesis streams that were not meant for uptycs to read.
- Updated the terraform script to add `kinesis_stream_policy` only for customer chosen kinesis stream if kinesis stream based cloudtrail logging is enabled. 
- Tested locally with cloudquery with two kinesis streams. But, only one of them was integrated using updated tf script on aws account. Got data only for one kinesis stream as expected while other one threw insufficient permission errors. 