### PR TITLE
CLD-3471: Added SSM permission

### DIFF
--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -101,7 +101,8 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
               "sns:GetSubscriptionAttributes",
               "sqs:ListQueues",
               "sqs:GetQueueAttributes",
-              "sqs:ListQueueTags"
+              "sqs:ListQueueTags",
+              "ssm:ListCommandInvocations"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
Added `ssm:ListCommandInvocations` permission in the terraform script according to this : https://github.com/Uptycs/uptycs/blob/aws_schema_v2/cloud/cloudquery/cf-templates/uptycs_integration-101-010.json

Issue : https://uptycsjira.atlassian.net/browse/CLD-3471