### PR TITLE
CSM-4712: Adding Permission for new tables

### DIFF
--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -53,7 +53,7 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
             "Effect": "Allow",
             "Action": [
               "apigateway:GET",
-              "codebuild:ListProjects"
+              "codebuild:ListProjects",
               "codecommit:GetCommit",
               "codecommit:GetRepository",
               "codecommit:GetBranch",

--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -53,15 +53,15 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
             "Effect": "Allow",
             "Action": [
               "apigateway:GET",
-	            "codebuild:ListProjects"
+              "codebuild:ListProjects"
               "codecommit:GetCommit",
               "codecommit:GetRepository",
               "codecommit:GetBranch",
               "codepipeline:ListTagsForResource",
               "codepipeline:GetPipeline",
               "ds:ListTagsForResource",
-	            "ec2:DescribeAccountAttributes",
-	            "ec2:GetEbsEncryptionByDefault",
+              "ec2:DescribeAccountAttributes",
+              "ec2:GetEbsEncryptionByDefault",
               "eks:ListNodegroups",
               "eks:DescribeFargateProfile",
               "eks:ListTagsForResource",

--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -53,12 +53,15 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
             "Effect": "Allow",
             "Action": [
               "apigateway:GET",
+	            "codebuild:ListProjects"
               "codecommit:GetCommit",
               "codecommit:GetRepository",
               "codecommit:GetBranch",
               "codepipeline:ListTagsForResource",
               "codepipeline:GetPipeline",
               "ds:ListTagsForResource",
+	            "ec2:DescribeAccountAttributes",
+	            "ec2:GetEbsEncryptionByDefault",
               "eks:ListNodegroups",
               "eks:DescribeFargateProfile",
               "eks:ListTagsForResource",


### PR DESCRIPTION
### Description:
  * Adding permissions to the APIs that are implemented in new tables:
      * aws_codebuild_project
      * aws_ec2_account_attribute