### PR TITLE
Adding permission for AWS-ec2:SearchTransitGatewayRoutes

### DIFF
--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -63,6 +63,7 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
               "ds:ListTagsForResource",
               "ec2:DescribeAccountAttributes",
               "ec2:GetEbsEncryptionByDefault",
+              "ec2:SearchTransitGatewayRoutes",
               "eks:DescribeAddon",
               "eks:DescribeCluster",
               "eks:DescribeFargateProfile",


### PR DESCRIPTION
Task Based on - https://uptycsjira.atlassian.net/browse/CSM-6950

Adding read permission for aws-`ec2 : SearchTransitGatewayRoutes`. Required for `table: "aws_ec2_transit_gw_routes"`