### PR TITLE
CSM-11439: Added get permission for aws lambda code signing config

### DIFF
--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -89,7 +89,7 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
               "ce:GetCostAndUsage",
               "redshift-serverless:List*",
               "lambda:GetCodeSigningConfig",
-			        "lambda:GetFunctionCodeSigningConfig"
+	      "lambda:GetFunctionCodeSigningConfig"
             ],
             "Resource": "*"
         }

--- a/modules/iam-profile/main.tf
+++ b/modules/iam-profile/main.tf
@@ -87,7 +87,9 @@ resource "aws_iam_policy" "ReadOnlyPolicy" {
               "sns:GetSubscriptionAttributes",
               "ssm:ListCommandInvocations",
               "ce:GetCostAndUsage",
-              "redshift-serverless:List*"
+              "redshift-serverless:List*",
+              "lambda:GetCodeSigningConfig",
+			        "lambda:GetFunctionCodeSigningConfig"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
Updated the terraform script by adding the new aws lambda permission to fetch the lambda function code signing config